### PR TITLE
- Don't apply linting labels 

### DIFF
--- a/include/common.esp
+++ b/include/common.esp
@@ -92,14 +92,6 @@ function FormData(o)
 				}
 				catch(e)
 				{
-with(new MailMessage())
-{
-	To = "debug@ontech.com.au";
-	From = "debug@ontech.com.au";
-	Subject = "NWO Form Data??";
-	TextBody = keyvalues.toSource() + "\n\n" + e.toSource() + "\n\n" + keyvalue[0] + ": " + keyvalue[1];
-	Send();
-}
 					throw e;
 				}
 			}			

--- a/include/github.esp
+++ b/include/github.esp
@@ -1,4 +1,3 @@
-//TODO This should become open source -- I think we should be transparent in our QA attempts to foster good will
 //TODO complete the secret hash checking stuff
 (function(){
 

--- a/tasks/linting/index.esp
+++ b/tasks/linting/index.esp
@@ -91,12 +91,6 @@ Github.Hooks.pull(/^\/linting\/lint/, Secret, function (Hook) {
 
 					if (LintStatus.warnings.length > 0 || LintStatus.errors.length > 0) {
 
-						if(!("static analysis failed" in Labels))
-							Github.Labels.Add(PullRequestNumber, "static analysis failed");
-						if("static analysis passed" in Labels)
-							Github.Labels.Remove(PullRequestNumber, "static analysis passed");
-
-
 						//Get list of files in this pull request
 						var FilesMap = Github.PullRequests.Files(PullRequestNumber);
 
@@ -106,6 +100,16 @@ Github.Hooks.pull(/^\/linting\/lint/, Secret, function (Hook) {
 							if(FileName in FilesMap) {
 
 								var FileCommitSha = FilesMap[FileName].sha;
+
+								if(!("static analysis failed" in Labels)) {
+
+									Github.Labels.Add(PullRequestNumber, "static analysis failed");
+									Github.Labels.Remove(PullRequestNumber, "static analysis passed");
+									
+									Labels["static analysis failed"] = true;
+								}
+
+
 
 								//Make sure the erroneous file is in the map above - you cannot leave comments on files that are not part of the changeset (git ignored etc)
 								Github.PullRequests.Comment(PullRequestNumber, FileCommitSha, FileName, Error.line, "BOT -> " + Error.text);

--- a/tasks/plugin/index.esp
+++ b/tasks/plugin/index.esp
@@ -169,7 +169,7 @@ Github.Hooks.push(/^\/plugin\/build/, Secret, function(Hook){
 					Logger.Log("GITHUB", ["Creating Release ", "TagName(", TagName, ") SHA1(" , TargetCommitSha, ")",
 						" Release Name ", ReleaseName, " TagDescription(" ,TagDescription, ")"].join(""), "Release");
 
-					//Github.Releases.Create(TagName, TargetCommitSha, ReleaseName, TagDescription, PreRelease, AssetPath);
+					Github.Releases.Create(TagName, TargetCommitSha, ReleaseName, TagDescription, PreRelease, AssetPath);
 
 					//Send notification to Slack room to inform developers a new build has been releases
 					Logger.Log("GITHUB", "Notifying developers release is ready", "Notifying in Slack");


### PR DESCRIPTION
* If there were linting warning/errors unless there is an error in the particular changeset
* Remove superfluous code